### PR TITLE
Reactify site

### DIFF
--- a/annsjon-spa.js
+++ b/annsjon-spa.js
@@ -1,0 +1,30 @@
+// Styling
+import './assets/less/main.less'
+
+// RiotControl Stores
+import './assets/js/stores/stores'
+
+// RiotJS tag(s)
+import './assets/js/tags/site-app'
+
+// RiotJS routing
+import Router from './assets/js/router'
+
+import React from 'react'
+import { render } from 'react-dom'
+
+import App from './components/App'
+
+const spaRoot = document.getElementById('spa-root')
+
+if (spaRoot) {
+  render(
+    <App>
+      <site-app />
+    </App>,
+    spaRoot,
+  )
+}
+
+riot.mount('*')
+Router()

--- a/assets/js/data/translations.js
+++ b/assets/js/data/translations.js
@@ -1,275 +1,304 @@
 const translations = {
     // Title
-    'site_title': {
+    site_title: {
         se: 'Ånnsjöns fågelstation',
-        en: 'Lake Ånnsjön Bird Observatory'
+        en: 'Lake Ånnsjön Bird Observatory',
     },
 
     // Misc
-    'language': {
+    language: {
         se: 'English',
-        en: 'Svenska'
+        en: 'Svenska',
     },
-    'credits': {
+    credits: {
         se: 'Design och utveckling av',
-        en: 'Design and development by'
+        en: 'Design and development by',
     },
     'read-more': {
-        se: 'Läs&nbsp;mer',
-        en: 'Read&nbsp;more'
+        se: 'Läs\u00a0mer',
+        en: 'Read\u00a0more',
     },
     'thank-you': {
         se: 'Tack',
-        en: 'Thank you'
+        en: 'Thank you',
     },
-    'yes': {
+    yes: {
         se: 'Ja',
-        en: 'Yes'
+        en: 'Yes',
     },
-    'no': {
+    no: {
         se: 'Nej',
-        en: 'No'
+        en: 'No',
     },
-    'select': {
+    select: {
         se: 'Välj',
-        en: 'Select'
+        en: 'Select',
     },
     'first-name': {
         se: 'Förnamn',
-        en: 'First name'
+        en: 'First name',
     },
     'last-name': {
         se: 'Efternamn',
-        en: 'Last name'
+        en: 'Last name',
     },
-    'email': {
+    email: {
         se: 'Epost',
-        en: 'Email'
+        en: 'Email',
     },
-    'phone': {
+    phone: {
         se: 'Telefon',
-        en: 'Phone'
+        en: 'Phone',
     },
 
     // Hero
-    'hero_body': {
+    hero_body: {
         se: 'En ideell förening som arbetar för ökad kunskap om fågellivet i västra Jämtland',
-        en: 'A non-profit organisation working for a better understanding about the birdlife in western Jämtland&nbsp;County in Sweden'
+        en:
+            'A non-profit organisation working for a better understanding about the birdlife in western Jämtland\u00a0County in Sweden',
     },
 
     // Annual Meeting
     'annual-meeting_header': {
         se: 'Årsmöte',
-        en: 'Annual General Meeting'
+        en: 'Annual General Meeting',
     },
     'annual-meeting_title': {
         se: 'Kallelse till årsmöte',
-        en: 'Notice of Annual General Meeting'
+        en: 'Notice of Annual General Meeting',
     },
     'annual-meeting_body': {
-        se: 'Lördagen den 1 juni, kl 13.00, anordnar styrelsen i Föreningen Ånnsjöns Fågelstation årsmöte i Handöl. Medlemmar i föreningen och allmänheten välkomnas att delta.',
-        en: 'The Board of Lake Ånnsjön Bird Observatory invites members and the public community to our Annual General Meeting in Handöl, June 1st 2019 at 1 pm.'
+        se:
+            'Lördagen den 1 juni, kl 13.00, anordnar styrelsen i Föreningen Ånnsjöns Fågelstation årsmöte i Handöl. Medlemmar i föreningen och allmänheten välkomnas att delta.',
+        en:
+            'The Board of Lake Ånnsjön Bird Observatory invites members and the public community to our Annual General Meeting in Handöl, June 1st 2019 at 1 pm.',
     },
 
     // Open House
-    'openhouse_header': {
+    openhouse_header: {
         se: 'Öppet Hus',
-        en: 'Open House'
+        en: 'Open House',
     },
-    'openhouse_title': {
+    openhouse_title: {
         se: 'Ånnsjödagen, 1 juni 2019',
-        en: 'Lake Ånnsjön Day, June 1st 2019'
+        en: 'Lake Ånnsjön Day, June 1st 2019',
     },
-    'openhouse_body': {
-        se: 'Ta med dina vänner till Ånnsjön när fågellivet är som mest sprudlande. Vi hjälper till med artbestämningen vid Ånnsjöns fågeltorn och gömslen under morgontimmarna, bjuder på bildvisning under kvällen och guidar er till en dubbelbeckasinlek vid midnatt.',
-        en: 'Bring your friends to Lake Ånnsjön when the birdlife is peaking. During the early hours we&#39;ll help you identify species at the observation towers by Lake Ånnsjön. During this day we arrange various activities and invites you to a guided tour of a Great Snipe lek at midnight!'
+    openhouse_body: {
+        se:
+            'Ta med dina vänner till Ånnsjön när fågellivet är som mest sprudlande. Vi hjälper till med artbestämningen vid Ånnsjöns fågeltorn och gömslen under morgontimmarna, bjuder på bildvisning under kvällen och guidar er till en dubbelbeckasinlek vid midnatt.',
+        en:
+            'Bring your friends to Lake Ånnsjön when the birdlife is peaking. During the early hours we&#39;ll help you identify species at the observation towers by Lake Ånnsjön. During this day we arrange various activities and invites you to a guided tour of a Great Snipe lek at midnight!',
     },
 
     // Volunteer
-    'volunteer_header': {
+    volunteer_header: {
         se: 'Medarbetare',
-        en: 'Volunteer'
+        en: 'Volunteer',
     },
-    'volunteer_title': {
+    volunteer_title: {
         se: 'Jobba med oss i sommar!',
-        en: 'Work with us this summmer!'
+        en: 'Work with us this summmer!',
     },
-    'volunteer_body': {
-        se: 'Inför säsongen 2016 söker vi vana fältornitologer till våra invent&shy;eringar, som väl känner till fjäll- och våtmarksarterna till utseende och läte. Till ringmärkningen söker vi erfarna ringmärkare och assistenter. Vi&nbsp;erbjuder fri logi och en oslagbar upplevelse i Ånnsjöfjällen.',
-        en: 'For the season 2016 we are looking for experienced field ornithologists that can determine mountain and wetland species by look and sound. For the ringing we are looking for experienced ringers and assistants. We&nbsp;offer free accommodation for volunteers and an unique visit to Lake Ånnsjön.'
+    volunteer_body: {
+        se:
+            'Inför säsongen 2016 söker vi vana fältornitologer till våra invent\u00aderingar, som väl känner till fjäll- och våtmarksarterna till utseende och läte. Till ringmärkningen söker vi erfarna ringmärkare och assistenter. Vi\u00a0erbjuder fri logi och en oslagbar upplevelse i Ånnsjöfjällen.',
+        en:
+            'For the season 2016 we are looking for experienced field ornithologists that can determine mountain and wetland species by look and sound. For the ringing we are looking for experienced ringers and assistants. We\u00a0offer free accommodation for volunteers and an unique visit to Lake Ånnsjön.',
     },
     'volunteer_button-apply': {
         se: 'Anmäl dig här',
-        en: 'Apply here'
+        en: 'Apply here',
     },
 
     // Projects
-    'projects_header': {
+    projects_header: {
         se: 'Några av våra projekt',
-        en: 'Some of our projects'
+        en: 'Some of our projects',
     },
     'projects_title-great-snipe': {
         se: 'Dubbelbeckasin',
-        en: 'Great Snipe'
+        en: 'Great Snipe',
     },
     'projects_body-great-snipe': {
-        se: 'Tillsammans med forskare från Lunds universitet studerar vi dubbel&shy;beckasinens flyttningar.',
-        en: 'Together with scientists from Lund University we study migratory movements of the Great Snipe.'
+        se:
+            'Tillsammans med forskare från Lunds universitet studerar vi dubbel\u00adbeckasinens flyttningar.',
+        en:
+            'Together with scientists from Lund University we study migratory movements of the Great Snipe.',
     },
     'projects_title-census': {
         se: 'Inventering',
-        en: 'Census project'
+        en: 'Census project',
     },
     'projects_body-census': {
-        se: 'Vi inventerar regelbundet Ånnsjön och omkring&shy;liggande myrar samt kalfjäll i området Ånnsjön-Storlien.',
-        en: 'Every spring we conduct census projects on Lake Ånnsjön and the surrounding mires and mountains.'
+        se:
+            'Vi inventerar regelbundet Ånnsjön och omkring\u00adliggande myrar samt kalfjäll i området Ånnsjön-Storlien.',
+        en:
+            'Every spring we conduct census projects on Lake Ånnsjön and the surrounding mires and mountains.',
     },
     'projects_title-ringing': {
         se: 'Ringmärkning',
-        en: 'Ringing'
+        en: 'Ringing',
     },
     'projects_body-ringing': {
-        se: 'Varje år bedriver vi standardiserad ring&shy;märkning av tättingar i Handöl och Enans delta.',
-        en: 'We annually ring between 2000-4000 passerines in the area of Handöl and in the Enan river delta.'
+        se:
+            'Varje år bedriver vi standardiserad ring\u00admärkning av tättingar i Handöl och Enans delta.',
+        en:
+            'We annually ring between 2000-4000 passerines in the area of Handöl and in the Enan river delta.',
     },
-    'projects_button': {
+    projects_button: {
         se: 'Se alla projekt',
-        en: 'See all projects'
+        en: 'See all projects',
     },
 
     // Guides
-    'guides_header': {
+    guides_header: {
         se: 'Vår skådarguide',
-        en: 'Our watcher\'s guide'
+        en: "Our watcher's guide",
     },
     'guides_body-handol': {
-        se: 'Längs älven Handölans lopp genom Handöl sträcker sig ett lummigt, löv&shy;skogs&shy;dominerat område med ett rikt fågelliv. Här hittar man trädgårds&shy;sångare, svarthätta…',
-        en: 'Along the river Handölan, through the village Handöl, there\'s a green, deciduous forest with a rich birdlife. Common species here are Garden Warbler, Blackcap, Icterine…'
+        se:
+            'Längs älven Handölans lopp genom Handöl sträcker sig ett lummigt, löv\u00adskogs\u00addominerat område med ett rikt fågelliv. Här hittar man trädgårds\u00adsångare, svarthätta…',
+        en:
+            "Along the river Handölan, through the village Handöl, there's a green, deciduous forest with a rich birdlife. Common species here are Garden Warbler, Blackcap, Icterine…",
     },
     'guides_body-hogasen': {
-        se: 'Dubbelbeckasinerna anländer till Ånnsjö&shy;fjällen omkring 15 maj, och börjar spela omedelbart. Spelet pågår intensivt någon vecka in i juni. Därefter är de flesta honor…',
-        en: 'The Greate snipe arrives to the mountains surrounding Lake Ånnsjön in mid May. They begin playing immediately and does so very intensively until mid June. After that most of…'
+        se:
+            'Dubbelbeckasinerna anländer till Ånnsjö\u00adfjällen omkring 15 maj, och börjar spela omedelbart. Spelet pågår intensivt någon vecka in i juni. Därefter är de flesta honor…',
+        en:
+            'The Greate snipe arrives to the mountains surrounding Lake Ånnsjön in mid May. They begin playing immediately and does so very intensively until mid June. After that most of…',
     },
     'guides_body-storlien': {
-        se: 'Området mellan Vindarnas tempel och Åhlénstugan brukar kunna bjuda på lappsparv, blåhake, fjällabb och kärrsnäppa. På Skurdals&shy;höjden finns även en välkänd…',
-        en: 'The area between the Temple of Winds and the Åhléns cabin usually offers Lapland Bunting, Bluethroat, Long-tailed Skua and Dunlin. There\'s also a well known Great Snipe lek…'
+        se:
+            'Området mellan Vindarnas tempel och Åhlénstugan brukar kunna bjuda på lappsparv, blåhake, fjällabb och kärrsnäppa. På Skurdals\u00adhöjden finns även en välkänd…',
+        en:
+            "The area between the Temple of Winds and the Åhléns cabin usually offers Lapland Bunting, Bluethroat, Long-tailed Skua and Dunlin. There's also a well known Great Snipe lek…",
     },
     'guides_body-storulvan': {
-        se: 'Här kan man se ripor av bägge arterna, blåhake och på högre höjd fjällpipare och snösparv. Både kungsörn och jaktfalk ses ibland vid Storulvån, men fjällvråk och sten…',
-        en: 'Among the more common species are Willow Grouse, Ptarmigan, Bluethroat and at higher altitude Dotterel and Snow Bunting. Golden Eagle and Gyr Falcon are rare, while Merlin…'
+        se:
+            'Här kan man se ripor av bägge arterna, blåhake och på högre höjd fjällpipare och snösparv. Både kungsörn och jaktfalk ses ibland vid Storulvån, men fjällvråk och sten…',
+        en:
+            'Among the more common species are Willow Grouse, Ptarmigan, Bluethroat and at higher altitude Dotterel and Snow Bunting. Golden Eagle and Gyr Falcon are rare, while Merlin…',
     },
     'guides_body-ann': {
-        se: 'På myrarna vid sjön är småspov, ljungpipare, grönbena, rödbena och gulärla karaktärsfåglar. Storspov, gluttsnäppa och enkel&shy;beckasin förekommer också…',
-        en: 'On the mires by Lake Ånnsjön typical species are Whimbrel, Golden Plover, Wood Sandpiper, Redshank and Yellow Wagtail. Other common species include Curlew, Greenshank…'
+        se:
+            'På myrarna vid sjön är småspov, ljungpipare, grönbena, rödbena och gulärla karaktärsfåglar. Storspov, gluttsnäppa och enkel\u00adbeckasin förekommer också…',
+        en:
+            'On the mires by Lake Ånnsjön typical species are Whimbrel, Golden Plover, Wood Sandpiper, Redshank and Yellow Wagtail. Other common species include Curlew, Greenshank…',
     },
-    'guides_button': {
+    guides_button: {
         se: 'Till skådarguiden',
-        en: 'See the guide'
+        en: 'See the guide',
     },
 
     // Volunteer
-    'volunteer_gender': {
+    volunteer_gender: {
         se: 'Kön',
-        en: 'Gender'
+        en: 'Gender',
     },
     'volunteer_gender-f': {
         se: 'Kvinna',
-        en: 'Female'
+        en: 'Female',
     },
     'volunteer_gender-m': {
         se: 'Man',
-        en: 'Male'
+        en: 'Male',
     },
-    'volunteer_birthyear': {
+    volunteer_birthyear: {
         se: 'Födelseår',
-        en: 'Birthyear'
+        en: 'Birthyear',
     },
-    'volunteer_about': {
+    volunteer_about: {
         se: 'Presentation',
-        en: 'Presentation'
+        en: 'Presentation',
     },
     'volunteer_about-hint': {
         se: 'Berätta om dig själv och tidigare erfarenheter med fåglar.',
-        en: 'Tell us about yourself and any previous experience with birds.'
+        en: 'Tell us about yourself and any previous experience with birds.',
     },
     'volunteer_arrival-date': {
         se: 'Datum för ankomst',
-        en: 'Arrival date'
+        en: 'Arrival date',
     },
     'volunteer_departure-date': {
         se: 'Datum för avfärd',
-        en: 'Departure date'
+        en: 'Departure date',
     },
     'volunteer_invalid-date': {
         se: 'Felaktigt datum',
-        en: 'Invalid date'
+        en: 'Invalid date',
     },
     'volunteer_dates-misplaced': {
         se: 'Ankomstdatum är senare än eller samma som avfärdsdatum.',
-        en: 'Arrival date is later than or same date as departure.'
+        en: 'Arrival date is later than or same date as departure.',
     },
-    'volunteer_timeframe': {
+    volunteer_timeframe: {
         se: 'Tidsram',
-        en: 'Timeframe'
+        en: 'Timeframe',
     },
     'volunteer_timeframe-hint': {
         se: 'Ange ungefär när du skulle vilja jobba hos oss och hur länge.',
-        en: 'Estimate when you would like to volunteer and for how long.'
+        en: 'Estimate when you would like to volunteer and for how long.',
     },
-    'volunteer_nationality': {
+    volunteer_nationality: {
         se: 'Nationalitet',
-        en: 'Nationality'
+        en: 'Nationality',
     },
-    'volunteer_car': {
+    volunteer_car: {
         se: 'Medför bil',
-        en: 'Arrives by car'
+        en: 'Arrives by car',
     },
     'volunteer_driving-license': {
         se: 'Körkort',
-        en: 'Driving license'
+        en: 'Driving license',
     },
-    'volunteer_mandatory': {
+    volunteer_mandatory: {
         se: 'Fält markerade med asterisk (<strong>*</strong>) är obligatoriska.',
-        en: 'Fields marked with asterisk (<strong>*</strong>) are mandatory.'
+        en: 'Fields marked with asterisk (<strong>*</strong>) are mandatory.',
     },
-    'volunteer_errors': {
+    volunteer_errors: {
         se: 'Vänligen korrigera eventuella fel för att skicka formuläret.',
-        en: 'Please correct any errors to submit the form.'
+        en: 'Please correct any errors to submit the form.',
     },
-    'volunteer_undelivered': {
-        se: '<strong>Formuläret skickades inte.</strong> Din ansökan kunde inte skickas på grund av tekniska problem. Vänligen skicka din ansökan till <a href="mailto:volunteer@annsjon.org">volunteer@annsjon.org</a> eller försök igen senare. Vi beklagar besväret!',
-        en: '<strong>Form submission failed.</strong> Your application could not be sent due to technical problems. Please consider applying to <a href="mailto:volunteer@annsjon.org">volunteer@annsjon.org</a> or try again later. We are sorry for the inconvenience!'
+    volunteer_undelivered: {
+        se:
+            '<strong>Formuläret skickades inte.</strong> Din ansökan kunde inte skickas på grund av tekniska problem. Vänligen skicka din ansökan till <a href="mailto:volunteer@annsjon.org">volunteer@annsjon.org</a> eller försök igen senare. Vi beklagar besväret!',
+        en:
+            '<strong>Form submission failed.</strong> Your application could not be sent due to technical problems. Please consider applying to <a href="mailto:volunteer@annsjon.org">volunteer@annsjon.org</a> or try again later. We are sorry for the inconvenience!',
     },
-    'volunteer_submit': {
+    volunteer_submit: {
         se: 'Skicka',
-        en: 'Submit'
+        en: 'Submit',
     },
-    'volunteer_submitting': {
+    volunteer_submitting: {
         se: 'Skickar…',
-        en: 'Submitting…'
+        en: 'Submitting…',
     },
-    'volunteer_confirmation': {
-        se: 'Din ansökan har skickats.<br>Vi återkommer till dig så snart vi har behandlat ärendet.',
-        en: 'Your application has been sent.<br>We will process it and get back to you as soon as possible.'
+    volunteer_confirmation: {
+        se:
+            'Din ansökan har skickats.<br>Vi återkommer till dig så snart vi har behandlat ärendet.',
+        en:
+            'Your application has been sent.<br>We will process it and get back to you as soon as possible.',
     },
 
     // Map
-    'map_header': {
+    map_header: {
         se: 'Här finns vi',
-        en: 'We are here'
+        en: 'We are here',
     },
-    'map_title': {
+    map_title: {
         se: 'Var håller vi till?',
-        en: 'Where we are'
+        en: 'Where we are',
     },
-    'map_body': {
-        se: 'Fågelstationen ligger i den lilla byn Handöl i västra Jämtland, inte långt ifrån norska gränsen. Hit tar man sig lättast med tåg, för vägbeskrivning se vår ',
-        en: 'The Observatory is situated in the tiny village of Handöl in Jämtland County, not far from the Norwegian border. The best way to get here is by train, for directions see our '
+    map_body: {
+        se:
+            'Fågelstationen ligger i den lilla byn Handöl i västra Jämtland, inte långt ifrån norska gränsen. Hit tar man sig lättast med tåg, för vägbeskrivning se vår ',
+        en:
+            'The Observatory is situated in the tiny village of Handöl in Jämtland County, not far from the Norwegian border. The best way to get here is by train, for directions see our ',
     },
-    'map_link': {
+    map_link: {
         se: 'Utforska platsen med ',
-        en: 'Explore the area with '
+        en: 'Explore the area with ',
     },
-};
+}
 
 export default translations

--- a/assets/js/tags/site-app.tag
+++ b/assets/js/tags/site-app.tag
@@ -1,18 +1,20 @@
 import RiotControl from 'riotcontrol'
 import utils from '../utils'
 
-import './layout-index.tag'
+// import './layout-index.tag'
 import './layout-page.tag'
-import './site-footer.tag'
-import './site-header.tag'
+// import './site-footer.tag'
+// import './site-header.tag'
+
+// <div class="site">
+//   <header data-is="site-header" class="site-header" />
+//   <main data-is="layout-index" if={ isIndex } />
+//   <main data-is="layout-page" ...
+// </div>
+// <footer data-is="site-footer" class="site-footer" />
 
 <site-app>
-    <div class="site">
-        <header data-is="site-header" class="site-header" />
-        <main data-is="layout-index" if={ isIndex } />
-        <main data-is="layout-page" if={ !isIndex } class="page" />
-    </div>
-    <footer data-is="site-footer" class="site-footer" />
+    <main data-is="layout-page" if={ !isIndex } class="page" />
 
     <script>
         const self = this

--- a/components/App.js
+++ b/components/App.js
@@ -1,0 +1,33 @@
+import React, { Fragment, useState } from 'react'
+import RiotControl from 'riotcontrol'
+
+import SiteFooter from './SiteFooter'
+import SiteHeader from './SiteHeader'
+import StartPage from './start-page/StartPage'
+
+import utils from '../assets/js/utils'
+
+const App = ({ children }) => {
+  const [isStartPage, setStartPage] = useState(true)
+  const [language, setLanguage] = useState('')
+
+  RiotControl.on('ROUTE', route => setStartPage(route === ''))
+
+  RiotControl.on('SITE_LANGUAGE', lang => {
+    setLanguage(lang)
+    utils.scrollUp()
+  })
+
+  return (
+    <Fragment>
+      <div className="site">
+        <SiteHeader />
+        {isStartPage && <StartPage language={language} />}
+        {children}
+      </div>
+      <SiteFooter />
+    </Fragment>
+  )
+}
+
+export default App

--- a/components/SiteFooter.js
+++ b/components/SiteFooter.js
@@ -1,0 +1,54 @@
+import React, { useState } from 'react'
+import RiotControl from 'riotcontrol'
+import purebem from 'purebem'
+
+import getText from '../assets/js/data/mygettext'
+
+const block = purebem.of('site-footer')
+
+const SiteFooter = () => {
+  const [links, setLinks] = useState([])
+  const [language, setLanguage] = useState('')
+
+  const changeLanguage = () => RiotControl.trigger('SET_SITE_LANGUAGE')
+
+  RiotControl.on('SITE_NAVIGATION_FOOTER', setLinks)
+  RiotControl.on('SITE_LANGUAGE', setLanguage)
+
+  return (
+    <footer className={block()}>
+      <div className="container">
+        <div className="row">
+          <a href="#" className={block('logo')}>
+            {getText('site_title')}
+          </a>
+          <nav className={block('links')}>
+            {links.map(({ href, label }) => (
+              <a key={href} className={block('link')} href={`#${href}`}>
+                {label}
+              </a>
+            ))}
+          </nav>
+        </div>
+        <div className="row">
+          <p className={block('misc')}>
+            <a href="#" className={block('misc-link', ['separator'])} onClick={changeLanguage}>
+              {getText('language')}
+            </a>
+            <a href="#cookies" className={block('misc-link')}>
+              Cookies
+            </a>
+            <span className={block('credits')}>
+              {getText('credits')}{' '}
+              <a href="http://twitter.com/tscok" target="_blank" className={block('misc-link')}>
+                Mikael Carlsson
+              </a>
+            </span>
+          </p>
+        </div>
+      </div>
+    </footer>
+  )
+}
+
+export default SiteFooter

--- a/components/SiteHeader.js
+++ b/components/SiteHeader.js
@@ -1,0 +1,56 @@
+import React, { useState } from 'react'
+import RiotControl from 'riotcontrol'
+import RiotRoute from 'riot-route'
+import purebem from 'purebem'
+
+const block = purebem.of('site-header')
+
+const SiteHeader = () => {
+  const [isExpaned, setExpanded] = useState(false)
+  const [links, setLinks] = useState([])
+  const [route, setRoute] = useState('')
+
+  const onToggleExpanded = () => setExpanded(state => !state)
+
+  const onReroute = (event, href) => {
+    event.preventDefault()
+    RiotRoute(href)
+    setExpanded(false)
+  }
+
+  RiotControl.on('ROUTE', newRoute => {
+    setRoute(newRoute)
+    setExpanded(false)
+  })
+
+  RiotControl.on('SITE_NAVIGATION_HEADER', setLinks)
+
+  return (
+    <header className={block()}>
+      <div className="container">
+        <div className="row">
+          <a href="#" className={block('logo')}>
+            Ånnsjöns fågelstation
+          </a>
+          <div id="burger" className={block('burger')} onClick={onToggleExpanded}>
+            <span className={block('burger-bar', { close: isExpaned })}></span>
+          </div>
+        </div>
+        <nav className={block('menu', { open: isExpaned })}>
+          {links.map(({ href, label }) => (
+            <a
+              key={href}
+              className={block('link', { active: href === route })}
+              href={`#${href}`}
+              onClick={event => onReroute(event, href)}
+            >
+              {label}
+            </a>
+          ))}
+        </nav>
+      </div>
+    </header>
+  )
+}
+
+export default SiteHeader

--- a/components/start-page/AnnualMeeting.js
+++ b/components/start-page/AnnualMeeting.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import purebem from 'purebem'
+
+import getText from '../../assets/js/data/mygettext'
+
+const block = purebem.of('annual-meeting')
+
+const AnnualMeeting = () => (
+  <section class={block()}>
+    <div class="container">
+      <h6 class={block('header')}>{getText('annual-meeting_header')}</h6>
+      <div class={block('main')}>
+        <h5 class={block('title')}>{getText('annual-meeting_title')}</h5>
+        <p class={block('body')}>{getText('annual-meeting_body')}</p>
+      </div>
+    </div>
+  </section>
+)
+
+export default AnnualMeeting

--- a/components/start-page/Guides.js
+++ b/components/start-page/Guides.js
@@ -1,0 +1,48 @@
+import React from 'react'
+import purebem from 'purebem'
+
+import getText from '../../assets/js/data/mygettext'
+
+const block = purebem.of('guides')
+
+const Guides = ({ language }) => (
+  <section className={block()}>
+    <div className="container">
+      <h6 className={block('header')}>{getText('guides_header')}</h6>
+      <div className="row">
+        <div className={`${block('brief')} one-half column`}>
+          <h5 className={block('title')}>Högåsen</h5>
+          <p className={block('body')}>
+            {getText('guides_body-hogasen')}
+            {language === 'se' && <a href="#guide/hogasen">{getText('read-more')}</a>}
+          </p>
+        </div>
+        <div className={`${block('brief')} one-half column`}>
+          <h5 className={block('title')}>Storulvån</h5>
+          <p className={block('body')}>
+            {getText('guides_body-storulvan')}
+            {language === 'se' && <a href="#guide/storulvan">{getText('read-more')}</a>}
+          </p>
+        </div>
+      </div>
+      <div className="row">
+        <div className={`${block('brief')} one-half column`}>
+          <h5 className={block('title')}>Storlien</h5>
+          <p className={block('body')}>
+            {getText('guides_body-storlien')}
+            {language === 'se' && <a href="#guide/storlien">{getText('read-more')}</a>}
+          </p>
+        </div>
+        <div className={`${block('brief')} one-half column`}>
+          <h5 className={block('title')}>Ånn</h5>
+          <p className={block('body')}>
+            {getText('guides_body-ann')}
+            {language === 'se' && <a href="#guide/ann">{getText('read-more')}</a>}
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+)
+
+export default Guides

--- a/components/start-page/Hero.js
+++ b/components/start-page/Hero.js
@@ -1,0 +1,15 @@
+import React from 'react'
+
+import getText from '../../assets/js/data/mygettext'
+
+const Hero = () => (
+  <section className="hero">
+    <div className="container">
+      <h1 className="hero__title">{getText('site_title')}</h1>
+      <hr className="hero__ruler" />
+      <h5 className="hero__body">{getText('hero_body')}</h5>
+    </div>
+  </section>
+)
+
+export default Hero

--- a/components/start-page/Location.js
+++ b/components/start-page/Location.js
@@ -1,0 +1,40 @@
+import React, { useEffect, useRef, useState } from 'react'
+import purebem from 'purebem'
+
+import LocationMap from './LocationMap'
+
+import getText from '../../assets/js/data/mygettext'
+
+const block = purebem.of('location')
+
+const Location = () => (
+  <section className={block()}>
+    <div className="container">
+      <div className="row">
+        <div className="one-half column">
+          <div className={block('map')}>
+            <LocationMap />
+          </div>
+        </div>
+        <div className="one-half column">
+          <h5 className={block('title')}>{getText('map_title')}</h5>
+          <p className={block('body')}>
+            {getText('map_body')}
+            <a href="#faq">FAQ</a>.
+            <span className={block('link')}>
+              {getText('map_link')}
+              <a
+                href="https://www.google.se/maps/place/63%C2%B015'30.5%22N+12%C2%B026'51.0%22E/@60.3825553,1.0879701,4.66z/data=!4m2!3m1!1s0x0:0x0"
+                target="_blank"
+              >
+                Google Maps
+              </a>
+            </span>
+          </p>
+        </div>
+      </div>
+    </div>
+  </section>
+)
+
+export default Location

--- a/components/start-page/LocationMap.js
+++ b/components/start-page/LocationMap.js
@@ -1,0 +1,37 @@
+import React, { useEffect, useRef, useState } from 'react'
+
+const HANDOL = new window.google.maps.LatLng(63.25847135123485, 12.447509765625)
+
+const CONFIG = {
+  center: HANDOL,
+  disableDefaultUI: true,
+  mapTypeId: window.google.maps.MapTypeId.TERRAIN,
+  scaleControl: false,
+  streetViewControl: false,
+  zoom: 4,
+  zoomControl: false,
+}
+
+const LocationMap = () => {
+  const [map, setMap] = useState(null)
+  const mapCanvas = useRef()
+
+  const setMarker = data => {
+    new window.google.maps.Marker({
+      position: HANDOL,
+      map: data,
+    })
+  }
+
+  useEffect(() => {
+    if (!map && mapCanvas.current) {
+      const data = new window.google.maps.Map(mapCanvas.current, CONFIG)
+      setMap(data)
+      setMarker(data)
+    }
+  }, [])
+
+  return <div id="mapCanvas" ref={mapCanvas} />
+}
+
+export default LocationMap

--- a/components/start-page/OpenHouse.js
+++ b/components/start-page/OpenHouse.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import purebem from 'purebem'
+
+import getText from '../../assets/js/data/mygettext'
+
+const block = purebem.of('open-house')
+
+const OpenHouse = () => (
+  <section class={block()}>
+    <div class="container">
+      <h6 class={block('header')}>{getText('openhouse_header')}</h6>
+      <div class={block('main')}>
+        <h5 class={block('title')}>{getText('openhouse_title')}</h5>
+        <p class={block('body')}>{getText('openhouse_body')}</p>
+      </div>
+      <div class={block('actions')}>
+        <a href="#open-house" class="button button-primary">
+          {getText('read-more')}
+        </a>
+      </div>
+    </div>
+  </section>
+)
+
+export default OpenHouse

--- a/components/start-page/Projects.js
+++ b/components/start-page/Projects.js
@@ -1,0 +1,40 @@
+import React from 'react'
+import purebem from 'purebem'
+
+import getText from '../../assets/js/data/mygettext'
+
+const block = purebem.of('projects')
+
+const Projects = ({ language }) => (
+  <section className={block()}>
+    <div className="container">
+      <h6 className={block('header')}>{getText('projects_header')}</h6>
+      <div className="row">
+        <div className={`${block('brief')} one-third column`}>
+          <div className={block('placeholder', ['great-snipe'])}></div>
+          <h5 className={block('title')}>{getText('projects_title-great-snipe')}</h5>
+          <p className={block('body')}>{getText('projects_body-great-snipe')}</p>
+        </div>
+        <div className={`${block('brief')} one-third column`}>
+          <div className={block('placeholder', ['census'])}></div>
+          <h5 className={block('title')}>{getText('projects_title-census')}</h5>
+          <p className={block('body')}>{getText('projects_body-census')}</p>
+        </div>
+        <div className={`${block('brief')} one-third column`}>
+          <div className={block('placeholder', ['ringing'])}></div>
+          <h5 className={block('title')}>{getText('projects_title-ringing')}</h5>
+          <p className={block('body')}>{getText('projects_body-ringing')}</p>
+        </div>
+      </div>
+      {language === 'se' && (
+        <div className={block('actions')}>
+          <a className={`${block('button')} button button-primary`} href="#projects">
+            {getText('projects_button')}
+          </a>
+        </div>
+      )}
+    </div>
+  </section>
+)
+
+export default Projects

--- a/components/start-page/StartPage.js
+++ b/components/start-page/StartPage.js
@@ -1,0 +1,19 @@
+import React from 'react'
+
+import Guides from './Guides'
+import Hero from './Hero'
+import Location from './Location'
+import Projects from './Projects'
+
+const StartPage = ({ language }) => {
+  return (
+    <main>
+      <Hero />
+      <Projects language={language} />
+      <Guides language={language} />
+      <Location />
+    </main>
+  )
+}
+
+export default StartPage

--- a/index.html
+++ b/index.html
@@ -1,18 +1,28 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="utf-8">
-    <meta name="author" content="Lake Ånnsjön Bird Observatory">
-    <meta name="description" content="A non-profit organisation working for a better understanding about the birdlife in western Jämtland county. | En ideell förening som arbetar för ökad kunskap om fågellivet i västra Jämtland.">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
-    <meta http-equiv="cache-control" content="max-age=31536000">
-    <title>annsjon.org</title>
-    <link rel="icon" href="favicon.gif" type="image/x-icon">
-    <link href="//fonts.googleapis.com/css?family=Raleway:400,300,600" rel="stylesheet" type="text/css">
-</head>
-<body>
-    <site-app></site-app>
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDU-QSezsFkEm9DikRmj7CH6RQnQIJhq4c"></script>
-    <script src="/build/bundle.js"></script>
-</body>
+    <head>
+        <meta charset="utf-8" />
+        <meta name="author" content="Lake Ånnsjön Bird Observatory" />
+        <meta
+            name="description"
+            content="A non-profit organisation working for a better understanding about the birdlife in western Jämtland county. | En ideell förening som arbetar för ökad kunskap om fågellivet i västra Jämtland."
+        />
+        <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no"
+        />
+        <meta http-equiv="cache-control" content="max-age=31536000" />
+        <title>annsjon.org</title>
+        <link rel="icon" href="favicon.gif" type="image/x-icon" />
+        <link
+            href="//fonts.googleapis.com/css?family=Raleway:400,300,600"
+            rel="stylesheet"
+            type="text/css"
+        />
+    </head>
+    <body>
+        <div id="spa-root"></div>
+        <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDU-QSezsFkEm9DikRmj7CH6RQnQIJhq4c"></script>
+        <script src="/build/bundle.js"></script>
+    </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "@babel/preset-env": "^7.8.4",
     "@babel/preset-react": "^7.8.3",
     "babel-loader": "^8.0.6",
-    "form-serialize": "^0.7.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"
   },
@@ -34,6 +33,7 @@
     "less-loader": "^4.0.5",
     "loader-utils": "^1.1.0",
     "markdown-loader": "^2.0.1",
+    "prettier": "^1.19.1",
     "purebem": "^1.0.0",
     "raw-loader": "^0.5.1",
     "riot": "^3.8.1",

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -1,24 +1,21 @@
-const webpack = require('webpack');
-const webpackMerge = require('webpack-merge');
+const webpack = require('webpack')
+const webpackMerge = require('webpack-merge')
 
-const baseConfig = require('./webpack.config.js');
-
+const baseConfig = require('./webpack.config.js')
 
 module.exports = function() {
-    return webpackMerge(baseConfig, {
-        output: {
-            publicPath: '/build/',
-        },
-        plugins: [
-            new webpack.HotModuleReplacementPlugin(),
-        ],
-        devServer: {
-            compress: true,
-            historyApiFallback: true,
-            host: '0.0.0.0',
-            hot: true,
-            inline: true,
-            publicPath: '/build/',
-        },
-    });
-};
+  return webpackMerge(baseConfig, {
+    output: {
+      publicPath: '/build/',
+    },
+    plugins: [new webpack.HotModuleReplacementPlugin()],
+    devServer: {
+      compress: true,
+      historyApiFallback: true,
+      host: '0.0.0.0',
+      hot: true,
+      inline: true,
+      publicPath: '/build/',
+    },
+  })
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,57 +1,46 @@
-const path = require('path');
-const webpack = require('webpack');
+const path = require('path')
+const webpack = require('webpack')
 
 module.exports = {
-    entry: './assets/js/main.js',
-    output: {
-        filename: 'bundle.js',
-        path: path.resolve(__dirname, 'build'),
-    },
-    module: {
-        rules: [
-            {
-                test: /\.tag?$/,
-                exclude: /node_modules/,
-                enforce: 'pre',
-                use: 'riotjs-loader'
-            },
-            {
-                test: /\.js$/,
-                exclude: /node_modules/,
-                use: ['babel-loader'],
-            },
-            {
-                test: /\.md?$/,
-                use: [
-                    'html-loader',
-                    { loader: 'markdown-loader', options: { breaks: true } },
-                ],
-            },
-            {
-                test: /\.less?$/,
-                use: [
-                    'style-loader',
-                    'css-loader',
-                    'less-loader',
-                ],
-            },
-            {
-                test: /\.(jpg|jpeg|png|svg)?$/i,
-                use: 'file-loader',
-            },
-        ],
-    },
-    plugins: [
-        new webpack.ProvidePlugin({
-            riot: 'riot'
-        }),
+  entry: './annsjon-spa.js',
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, 'build'),
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tag?$/,
+        exclude: /node_modules/,
+        enforce: 'pre',
+        use: 'riotjs-loader',
+      },
+      {
+        test: /\.js$/,
+        exclude: /node_modules/,
+        use: ['babel-loader'],
+      },
+      {
+        test: /\.md?$/,
+        use: ['html-loader', { loader: 'markdown-loader', options: { breaks: true } }],
+      },
+      {
+        test: /\.less?$/,
+        use: ['style-loader', 'css-loader', 'less-loader'],
+      },
+      {
+        test: /\.(jpg|jpeg|png|svg)?$/i,
+        use: 'file-loader',
+      },
     ],
-    resolve: {
-        modules: [
-            path.resolve(__dirname, './'),
-            path.resolve(__dirname, 'assets'),
-            'node_modules',
-        ],
-        extensions: ['.js', '.tag', '.md', '.less'],
-    },
-};
+  },
+  plugins: [
+    new webpack.ProvidePlugin({
+      riot: 'riot',
+    }),
+  ],
+  resolve: {
+    modules: [path.resolve(__dirname, './'), path.resolve(__dirname, 'assets'), 'node_modules'],
+    extensions: ['.js', '.tag', '.md', '.less'],
+  },
+}

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -1,24 +1,23 @@
-const webpack = require('webpack');
-const webpackMerge = require('webpack-merge');
+const webpack = require('webpack')
+const webpackMerge = require('webpack-merge')
 
-const baseConfig = require('./webpack.config.js');
+const baseConfig = require('./webpack.config.js')
 
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
-
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin')
 
 module.exports = function() {
-    return webpackMerge(baseConfig, {
-        plugins: [
-            new webpack.LoaderOptionsPlugin({
-                minimize: true,
-                debug: false
-            }),
-            new webpack.DefinePlugin({
-                'process.env': {
-                    'NODE_ENV': JSON.stringify('production')
-                }
-            }),
-            new UglifyJsPlugin()
-        ],
-    });
-};
+  return webpackMerge(baseConfig, {
+    plugins: [
+      new webpack.LoaderOptionsPlugin({
+        minimize: true,
+        debug: false,
+      }),
+      new webpack.DefinePlugin({
+        'process.env': {
+          NODE_ENV: JSON.stringify('production'),
+        },
+      }),
+      new UglifyJsPlugin(),
+    ],
+  })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3358,7 +3358,7 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-form-serialize@^0.7.0:
+form-serialize@^0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/form-serialize/-/form-serialize-0.7.2.tgz#b0a2ff0c22026fb6d3d15c9d33f6de6a432e4732"
   integrity sha1-sKL/DCICb7bT0VydM/beakMuRzI=
@@ -6325,6 +6325,11 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
+
+prettier@^1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-error@^2.0.2:
   version "2.1.1"


### PR DESCRIPTION
Adds a new entry point for the app, `annsjon-spa.js`, which includes both Riot and React.

Replaces Header, Footer and Start page with React components.

Other "pages" are still rendered using Riot.

Converted some HTML characters in `translations.js` to ASCII so they can be properly rendered without the `raw` (Riot) tag or React's `dangerouslySetInnerHTML`.