### PR TITLE
Splits out MUI to separate chunk

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -24,4 +24,13 @@ export default defineConfig({
       exclude: '',
     }),
   ],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          mui: ['@mui/material', '@mui/icons-material'],
+        },
+      },
+    },
+  },
 })


### PR DESCRIPTION
Adds rollup build option to create a separate chunk for `mui/material` and `mui/icons-material`